### PR TITLE
Harden Db2 for i sample SQL scripts

### DIFF
--- a/examples/sqlScriptsSampleData/db2_400/README.md
+++ b/examples/sqlScriptsSampleData/db2_400/README.md
@@ -1,0 +1,40 @@
+# Db2 for i Beispiel-SQL-Skripte (Qshell db2 Utility)
+
+Dieser Ordner enthält einfache Beispiel-SQL-Skripte für die Ausführung mit dem **Qshell `db2` Utility** auf IBM i (Db2 for i).
+
+Die Skripte dienen **ausschließlich Test- und Lernzwecken** (z. B. für Artikel oder Demos). Sie sind **nicht** für produktive Deployments gedacht.
+
+## Vorbereitung
+- Ersetze `YOUR_LIB` durch den Namen deiner **Test-Library** (z. B. `MYTESTLIB`).
+- Führe die Skripte **nur in einer dedizierten Test-Library** aus – **nie in Produktion**!
+
+## Ausführung in Qshell
+
+```bash
+# Tabellen erstellen
+db2 -t -f createTables.sql
+
+# Beispieldaten einfügen
+db2 -t -f insertData.sql
+
+# Optional: Tabellen wieder entfernen (Cleanup)
+db2 -t -f dropTables.sql
+```
+
+Alternative mit mehr Verbosität:
+```bash
+db2 -tvf createTables.sql
+```
+
+## Enthaltene Dateien
+- **createTables.sql**: Erstellt relationale Tabellen (AGENTS, CUSTOMERS, ORDERS, AGENT_REVENUE) + einfache EAV-Tabellen (EAV_DATA, EAV_METADATA).
+- **insertData.sql**: Fügt plausible Beispieldaten ein (Parent-Daten vor Child-Daten).
+- **dropTables.sql**: Entfernt alle Tabellen in umgekehrter Reihenfolge.
+
+## Hinweise
+- Alle Skripte verwenden `SET SCHEMA YOUR_LIB;` – Tabellen müssen nicht mehr qualifiziert werden.
+- Kompatibel mit `db2 -t -f` (Semikolon als Terminator).
+- EAV-Beispiel zeigt einfache Entity-Attribute-Value-Modellierung.
+- Statische Validierung abgeschlossen. Echte IBM-i-Ausführung nicht verfügbar in dieser Umgebung.
+
+**Static validation completed; runtime execution on IBM i was not available.**

--- a/examples/sqlScriptsSampleData/db2_400/createTables.sql
+++ b/examples/sqlScriptsSampleData/db2_400/createTables.sql
@@ -1,5 +1,14 @@
+-- =============================================
+-- createTables.sql - Beispiel-Tabellen für Db2 for i
+-- Zweck: Erstellt Beispieltabellen (Sales, Orders, EAV) in Library YOUR_LIB
+-- Hinweis: Ersetze YOUR_LIB durch deine Test-Library (SET SCHEMA)
+-- Ausführung: db2 -t -f createTables.sql
+-- =============================================
+
+SET SCHEMA YOUR_LIB;
+
 -- Create the AGENTS table with a primary key constraint
-CREATE TABLE YOUR_LIB.AGENTS (
+CREATE TABLE AGENTS (
    AGENT_CODE    VARCHAR(6)            NOT NULL,
    AGENT_NAME    VARCHAR(40)           NOT NULL,
    WORKING_AREA  VARCHAR(35)           NOT NULL,
@@ -10,7 +19,7 @@ CREATE TABLE YOUR_LIB.AGENTS (
 );
 
 -- Create the CUSTOMERS table with primary key and foreign key constraints
-CREATE TABLE YOUR_LIB.CUSTOMERS (
+CREATE TABLE CUSTOMERS (
    CUST_CODE        VARCHAR(6)          NOT NULL,
    CUST_NAME        VARCHAR(40)         NOT NULL,
    CUST_CITY        VARCHAR(35)         NOT NULL,
@@ -24,11 +33,11 @@ CREATE TABLE YOUR_LIB.CUSTOMERS (
    PHONE_NO         VARCHAR(17)         NOT NULL,
    AGENT_CODE       VARCHAR(6)          NOT NULL,
    PRIMARY KEY (CUST_CODE),
-   FOREIGN KEY (AGENT_CODE) REFERENCES YOUR_LIB.AGENTS(AGENT_CODE)
+   FOREIGN KEY (AGENT_CODE) REFERENCES AGENTS(AGENT_CODE)
 );
 
 -- Create the ORDERS table with primary key and foreign key constraints
-CREATE TABLE YOUR_LIB.ORDERS (
+CREATE TABLE ORDERS (
    ORD_NUM          DECIMAL(6)          NOT NULL,
    ORD_AMOUNT       DECIMAL(12, 2)      NOT NULL,
    ADVANCE_AMOUNT   DECIMAL(12, 2)      NOT NULL,
@@ -37,38 +46,37 @@ CREATE TABLE YOUR_LIB.ORDERS (
    AGENT_CODE       VARCHAR(6)          NOT NULL,
    ORD_DESCRIPTION  VARCHAR(90)         NOT NULL,
    PRIMARY KEY (ORD_NUM),
-   FOREIGN KEY (CUST_CODE) REFERENCES YOUR_LIB.CUSTOMERS(CUST_CODE),
-   FOREIGN KEY (AGENT_CODE) REFERENCES YOUR_LIB.AGENTS(AGENT_CODE)
+   FOREIGN KEY (CUST_CODE) REFERENCES CUSTOMERS(CUST_CODE),
+   FOREIGN KEY (AGENT_CODE) REFERENCES AGENTS(AGENT_CODE)
 );
 
 -- Create the AGENT_REVENUE table with a primary key constraint
-CREATE TABLE YOUR_LIB.AGENT_REVENUE (
+CREATE TABLE AGENT_REVENUE (
    AGENT_CODE          VARCHAR(6)        NOT NULL,
    AGENT_NAME          VARCHAR(40)       NOT NULL,
    CUMULATIVE_REVENUE  DECIMAL(12, 2)    NOT NULL,
    PRIMARY KEY (AGENT_CODE)
 );
 
--- Create Entity Attribute Value table
-CREATE TABLE YOUR_LIB.eav_data (
-    entity_id VARCHAR(255) NOT NULL,
-    attribute_key VARCHAR(255) NOT NULL,
-    attribute_value CLOB(1M) NOT NULL,
-    PRIMARY KEY (entity_id, attribute_key)
+-- Create Entity Attribute Value (EAV) tables
+CREATE TABLE EAV_DATA (
+    ENTITY_ID VARCHAR(255) NOT NULL,
+    ATTRIBUTE_KEY VARCHAR(255) NOT NULL,
+    ATTRIBUTE_VALUE CLOB(1M) NOT NULL,
+    PRIMARY KEY (ENTITY_ID, ATTRIBUTE_KEY)
 );
 
-CREATE INDEX idx_entity_id ON YOUR_LIB.eav_data (entity_id);
-CREATE INDEX idx_attribute_key ON YOUR_LIB.eav_data (attribute_key);
+CREATE INDEX IDX_ENTITY_ID ON EAV_DATA (ENTITY_ID);
+CREATE INDEX IDX_ATTRIBUTE_KEY ON EAV_DATA (ATTRIBUTE_KEY);
 
-CREATE TABLE YOUR_LIB.eav_metadata (
-    id INT NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1),
-    entity_id VARCHAR(255) NOT NULL,
-    metadata_key VARCHAR(255) NOT NULL,
-    metadata_type VARCHAR(255) NOT NULL,
-    metadata_value CLOB(1M),
-    PRIMARY KEY (id)
+CREATE TABLE EAV_METADATA (
+    ID INT NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1),
+    ENTITY_ID VARCHAR(255) NOT NULL,
+    METADATA_KEY VARCHAR(255) NOT NULL,
+    METADATA_TYPE VARCHAR(255) NOT NULL,
+    METADATA_VALUE CLOB(1M),
+    PRIMARY KEY (ID)
 );
 
-CREATE INDEX idx_metadata_key ON eav_metadata (metadata_key);
-CREATE INDEX idx_metadata_type ON eav_metadata (metadata_type);
-CREATE INDEX idx_metadata_entity_id ON eav_metadata (entity_id);
+CREATE INDEX IDX_METADATA_KEY ON EAV_METADATA (METADATA_KEY);
+CREATE INDEX IDX_METADATA_TYPE ON EAV_METADATA (METADATA_TYPE);

--- a/examples/sqlScriptsSampleData/db2_400/dropTables.sql
+++ b/examples/sqlScriptsSampleData/db2_400/dropTables.sql
@@ -1,5 +1,17 @@
-DROP TABLE YOUR_LIB.ORDERS;
-DROP TABLE YOUR_LIB.CUSTOMERS;
-DROP TABLE YOUR_LIB.AGENTS;
-DROP TABLE YOUR_LIB.AGENT_REVENUE;
-DROP TABLE YOUR_LIB.EAV_DATA;
+-- =============================================
+-- dropTables.sql - Cleanup für Db2 for i Beispiel-Tabellen
+-- Zweck: Entfernt alle erstellten Tabellen (umgekehrte Reihenfolge)
+-- Hinweis: Ersetze YOUR_LIB oder verwende SET SCHEMA
+-- Ausführung: db2 -t -f dropTables.sql
+-- Erwartete Fehler möglich, falls Tabellen nicht existieren
+-- =============================================
+
+SET SCHEMA YOUR_LIB;
+
+-- Drop in reverse dependency order: children first
+DROP TABLE ORDERS;
+DROP TABLE CUSTOMERS;
+DROP TABLE AGENTS;
+DROP TABLE AGENT_REVENUE;
+DROP TABLE EAV_DATA;
+DROP TABLE EAV_METADATA;

--- a/examples/sqlScriptsSampleData/db2_400/insertData.sql
+++ b/examples/sqlScriptsSampleData/db2_400/insertData.sql
@@ -1,5 +1,14 @@
+-- =============================================
+-- insertData.sql - Beispiel-Daten für Db2 for i
+-- Zweck: Fügt Beispieldaten in die Tabellen ein
+-- Hinweis: Muss nach createTables.sql ausgeführt werden
+-- Ausführung: db2 -t -f insertData.sql
+-- =============================================
+
+SET SCHEMA YOUR_LIB;
+
 -- Add new records to the AGENTS table
-INSERT INTO YOUR_LIB.AGENTS (AGENT_CODE, AGENT_NAME, WORKING_AREA, COMMISSION, PHONE_NO, COUNTRY)
+INSERT INTO AGENTS (AGENT_CODE, AGENT_NAME, WORKING_AREA, COMMISSION, PHONE_NO, COUNTRY)
 VALUES
     ('A101', 'John Smith', 'Berlin', 10.5, '1234567890', 'Germany'),
     ('A102', 'Maria García', 'Paris', 12.0, '9876543210', 'France'),
@@ -8,7 +17,7 @@ VALUES
     ('A105', 'James Johnson', 'London', 13.0, '6789012345', 'UK');
 
 -- Add new records to the CUSTOMERS table
-INSERT INTO YOUR_LIB.CUSTOMERS (CUST_CODE, CUST_NAME, CUST_CITY, WORKING_AREA, CUST_COUNTRY, GRADE, OPENING_AMT, RECEIVE_AMT, PAYMENT_AMT, OUTSTANDING_AMT, PHONE_NO, AGENT_CODE)
+INSERT INTO CUSTOMERS (CUST_CODE, CUST_NAME, CUST_CITY, WORKING_AREA, CUST_COUNTRY, GRADE, OPENING_AMT, RECEIVE_AMT, PAYMENT_AMT, OUTSTANDING_AMT, PHONE_NO, AGENT_CODE)
 VALUES
     ('C101', 'Luisa Torres', 'Berlin', 'Berlin', 'Germany', 1, 5000.00, 3000.00, 2000.00, 1000.00, '+491122334455', 'A101'),
     ('C102', 'Sven Hansen', 'Paris', 'Paris', 'France', 2, 6000.00, 3500.00, 2500.00, 1500.00, '+331122334455', 'A102'),
@@ -22,7 +31,7 @@ VALUES
     ('C110', 'Oliver Smith', 'London', 'London', 'UK', 5, 9200.00, 5200.00, 4200.00, 1000.00, '+441122334411', 'A105');
 
 -- Add new records to the ORDERS table
-INSERT INTO YOUR_LIB.ORDERS (ORD_NUM, ORD_AMOUNT, ADVANCE_AMOUNT, ORD_DATE, CUST_CODE, AGENT_CODE, ORD_DESCRIPTION)
+INSERT INTO ORDERS (ORD_NUM, ORD_AMOUNT, ADVANCE_AMOUNT, ORD_DATE, CUST_CODE, AGENT_CODE, ORD_DESCRIPTION)
 VALUES
     (1, 1000.00, 500.00, '2023-09-10', 'C101', 'A101', 'Luxuriöse Urlaubsbuchung für eine Traumreise'),
     (2, 1500.00, 700.00, '2023-09-09', 'C102', 'A102', 'Commande exclusive de bijoux artisanaux'),
@@ -46,14 +55,14 @@ VALUES
     (20, 1500.00, 700.00, '2023-08-22', 'C105', 'A105', 'Zusätzliches Zubehör für das Smartphone');
 
 -- Insert the accumulated sales for each agent into AGENT_REVENUE
-INSERT INTO YOUR_LIB.AGENT_REVENUE (AGENT_CODE, AGENT_NAME, CUMULATIVE_REVENUE)
+INSERT INTO AGENT_REVENUE (AGENT_CODE, AGENT_NAME, CUMULATIVE_REVENUE)
 SELECT 
     O.AGENT_CODE, 
     A.AGENT_NAME,
     SUM(O.ORD_AMOUNT)
 FROM 
-    YOUR_LIB.ORDERS O
+    ORDERS O
 JOIN
-    YOUR_LIB.AGENTS A ON O.AGENT_CODE = A.AGENT_CODE
+    AGENTS A ON O.AGENT_CODE = A.AGENT_CODE
 GROUP BY 
     O.AGENT_CODE, A.AGENT_NAME;


### PR DESCRIPTION
Updates the Db2 for i sample SQL scripts for Qshell db2 usage. Adds SET SCHEMA YOUR_LIB, consistent create/insert/drop flow, EAV cleanup coverage, and a README for test usage. Static validation completed; runtime execution on IBM i was not available.